### PR TITLE
Add tab character + UTF-8 support

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -305,7 +305,7 @@ sed '
 
 # Now pass the code through `pygmentize` for syntax highlighting. We tell it
 # the the input is `sh` and that we want HTML output.
-$PYGMENTIZE -l sh -f html                   |
+$PYGMENTIZE -l sh -f html -O encoding=utf8  |
 
 # Post filter the pygments output to remove partial `<pre>` blocks. We add
 # these back in at each section when we build the output document.


### PR DESCRIPTION
Hi.

First time using git, using gihub, and using pull requests, so please excuse me if I am doing something out of protocol.

I added a couple of IMHO handy edits to your code:
- Support tabs for code nesting: if the script had comments indented with tabs, shocco would not recognize them as documentation. With this patch, both spaces and tabs at the begining of a line have the same status. Solves #9.
- Support non-ASCII characters in code: if code portions contained international characters (such as accented latin characters or chinese ideograms) shocco would break. With this patch both code and documentation can contain any UTF-8 character. Solves #10.
