### PR TITLE
Fix for issue #7, misaligned docs/code blocks on GNU systems 

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -74,7 +74,7 @@ MARKDOWN='@@MARKDOWN@@'
 PYGMENTIZE='@@PYGMENTIZE@@'
 
 # On GNU systems, csplit doesn't elide empty files by default:
-CSPLITARGS=$( (csplit --version 2>/dev/null | grep -i gnu >/dev/null) && echo "--elide-empty-files" )
+CSPLITARGS=$( (csplit --version 2>/dev/null | grep -i gnu >/dev/null) && echo "--elide-empty-files" || true )
 
 # We're going to need a `markdown` command to run comments through. This can
 # be [Gruber's `Markdown.pl`][md] (included in the shocco distribution) or


### PR DESCRIPTION
This adds a check for GNU csplit and adds in the argument --elide-empty-files to bring the behavior more inline with BSD csplit.

More details on the issue comment:
https://github.com/rtomayko/shocco/issues/7#issuecomment-1817703
