### PR TITLE
Typo fix: 'http-equiv', not 'http-eqiv'

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -343,7 +343,7 @@ layout () {
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-eqiv='content-type' content='text/html;charset=utf-8'>
+    <meta http-equiv='content-type' content='text/html;charset=utf-8'>
     <title>$1</title>
     <link rel=stylesheet href="http://jashkenas.github.com/docco/resources/docco.css">
 </head>


### PR DESCRIPTION
HTML header contains incorrect meta-tag with `<meta http-eqiv='content-type' content='text/html;charset=utf-8'>`. Note `http-eqiv`, it makes UTF-8 characters look ugly in browser, as it ignores this incorrect header.

The commit contains typo fix.
