### PR TITLE
Fix expansion of $file

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -169,7 +169,7 @@ trap "rm -rf $WORK" 0
         # flip-flopping the two headings.
         lineno=$(( $lineno + 1 ))
         test $lineno = 1 && ! expr "$line" : "#!.*" >/dev/null &&
-        echo "$(basename $0): $(file):1 [warn] shebang! line missing." 1>&2
+        echo "$(basename $0): ${file}:1 [warn] shebang! line missing." 1>&2
 
         # Accumulate comment lines into `$docsbuf` and code lines into
         # `$codebuf`. Only lines matching `/#(?: |$)/` are considered doc


### PR DESCRIPTION
The message warning of a missing shebang! line clearly intended to output
which file was missing the shebang, but instead it accidentally invoked the
file(1) command with no arguments, resulting in an error.
